### PR TITLE
Add options to change cover image kind and supplement

### DIFF
--- a/isc_template_report.typ
+++ b/isc_template_report.typ
@@ -150,7 +150,7 @@
     } else if (it.func() == raw){
       "Listing"
     } else{
-      panic(it.func())
+      auto
     }
   }  
 

--- a/isc_template_report.typ
+++ b/isc_template_report.typ
@@ -34,6 +34,8 @@
   cover-image: none,
   cover-image-height: 10cm,
   cover-image-caption: "KNN exposed, by Marcus Volg",
+  cover-image-kind: auto,
+  cover-image-supplement: auto,
     
   // A list of authors, separated by commas
   authors: (),
@@ -215,9 +217,15 @@
   v(10fr, weak: true)
 
   // Puts a default cover image
-  if cover-image != none{    
-      show figure.caption: emph      
-      figure(box(cover-image, height: cover-image-height), caption: cover-image-caption, numbering: none)
+  if cover-image != none {
+    show figure.caption: emph
+    figure(
+      box(cover-image, height: cover-image-height),
+      caption: cover-image-caption,
+      numbering: none,
+      kind: cover-image-kind,
+      supplement: cover-image-supplement
+    )
   }
 
   v(10fr, weak: true)


### PR DESCRIPTION
I would find useful to have the option to change the cover image kind and supplement, if someone wants to put a CeTZ canvas for example

On the same topic, I find it quite restricting to panic if the figure type is not one handled by the function `getSupplement` (and no supplement is given). I have changed it to fallback on an `auto` value, which shouldn't make much of a difference, except not throwing an error.