### PR TITLE
Fix: isc_template.typ filepath inside lib/pages/cover_bachelor.typ

### DIFF
--- a/lib/pages/cover_bachelor.typ
+++ b/lib/pages/cover_bachelor.typ
@@ -1,6 +1,6 @@
 #import "../includes.typ" as inc
 #import "../overflow.typ" as overflow
-#import "/isc_templates.typ" as isc
+#import "../../isc_templates.typ" as isc
 
 // Adapted from https://github.com/LasseRosenow/HAW-Hamburg-Typst-Template/tree/main
 
@@ -150,9 +150,9 @@
       v(70mm),
       // Title
       title_block,
-      
+
       v(5mm),
-      
+
       // Decorative line: hash-encoded bit pattern (square ends + circle bits).
       // Its width matches the programme text rendered just below it, so measure
       // that line and feed the result to hash-rule as its length.


### PR DESCRIPTION
# Fix: isc_template.typ filepath inside lib/pages/cover_bachelor.typ

## What does this PR do?

This pr fixes the `isc_template.typ` filepath inside the `lib/pages/cover_bachelor.typ` file

by changing it from `/isc_templates.typ` to `../../isc_templates.typ`


## Why this PR?

The old path resulted in the following error when trying to use the template:

```
error: file not found (searched at bachelor-thesis-report/isc_templates.typ)
  ┌─ isc-hei-typst-templates/lib/pages/cover_bachelor.typ:3:8
  │
3 │ #import "/isc_templates.typ" as isc
  │         ^^^^^^^^^^^^^^^^^^^^

help: error occurred while importing this module
    ┌─ isc-hei-typst-templates/lib/covers.typ:123:11
    │
123 │     import "pages/cover_bachelor.typ": cover_page
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^

help: error occurred in this call of function `front-matter`
    ┌─ isc-hei-typst-templates/lib/project.typ:391:2
    │
391 │ ╭   front-matter(
392 │ │     doc-type: doc-type,
393 │ │     show-cover: show-cover,
394 │ │     no-decorations: no-decorations,
    · │
429 │ │     footer: footer,
430 │ │   )
    │ ╰───^