### PR TITLE
Fix: sample-thesis-id inside lib/pages/cover_bachelor.typ

### DIFF
--- a/lib/pages/cover_bachelor.typ
+++ b/lib/pages/cover_bachelor.typ
@@ -39,7 +39,7 @@
   // its shipped placeholder — including being emptied) we flag every required
   // field still left empty or at its shipped placeholder value.
   let sample-author    = "Margaret Hamilton"
-  let sample-thesis-id = "ISC-ID-26-1"
+  let sample-thesis-id = "ISC-ID-26-0"
   let sample-repo      = "https://github.com/ISC-HEI/isc-hei-typst-templates"
   let sample-keywords  = ("engineering", "data", "machine learning", "meteorology")
   // Expected reference format: ISC-XX-YY-N (XX = two letters, YY = two-digit
@@ -150,9 +150,9 @@
       v(70mm),
       // Title
       title_block,
-      
+
       v(5mm),
-      
+
       // Decorative line: hash-encoded bit pattern (square ends + circle bits).
       // Its width matches the programme text rendered just below it, so measure
       // that line and feed the result to hash-rule as its length.


### PR DESCRIPTION
# Fix: sample-thesis-id inside lib/pages/cover_bachelor.typ

## What does this PR do?

This PR changes the `sample-thesis-id` inside `lib/pages/cover_bachelor.typ` from `ISC-ID-26-1` to `ISC-ID-26-0`

## Why this PR?

As the student with the bachelor thesis ID ISC-ID-26-1 I was unable to use the template without getting the following warning:

```
— The thesis reference (thesis-id) has not been updated
```