### PR TITLE
Enh: Add a Nix flake for reproducible dev environments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test
 .Spotlight-V100
 .Trashes
 ._*
+
+# Ignore direnv folder
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Developmen flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        fontsConf = pkgs.makeFontsConf {
+          fontDirectories = with pkgs; [
+            fira-code
+            source-sans
+            source-sans-pro
+            inriafonts
+          ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            typst
+            tinymist
+            just
+            pngquant
+            zopfli
+          ];
+
+          shellHook = ''
+            export FONTCONFIG_FILE="${fontsConf}"
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Developmen flake";
+  description = "Development Flake";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";


### PR DESCRIPTION
# Enh: Add a Nix flake for reproducible dev environments

## Why this PR?

Setting up the local development environment currently requires manually installing several dependencies (typst, tinymist, just, pngquant, zopfli, and fonts).

This PR adds a Nix flake that provides a fully reproducible dev shell with all required dependencies pre-configured for users using the [Nix](https://nixos.org/) package manager.

## What this PR does

This PR introduces 3 new files:
- `flake.nix` / `flake.lock` which defines the dev shell with typst, tinymist, just, pngquant, zopfli, and fonts
- `.envrc` allows to auto-enters the shell via `nix-direnv` on `cd`

The `gitignore` was also updated to ignore the `direnv` generated `.direnv` folder

## How to use
```bash
# With Nix installed and flakes enabled:
nix develop

# Or with direnv + nix-direnv:
direnv allow  # only needed once